### PR TITLE
Fix missing export in auth page

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -82,3 +82,11 @@ function AuthContent() {
     </div>
   );
 }
+
+export default function AuthPage() {
+  return (
+    <Suspense>
+      <AuthContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- fix `src/app/auth/page.tsx` so it exports a valid Next.js page component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842a6624688832895ac56ff43582992