### PR TITLE
Fix build by marking dynamic routes

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 // Redirect users to our new auth system
 export function GET() {
   return NextResponse.redirect(new URL('/auth', process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'));

--- a/src/app/api/auth/callback/google/route.ts
+++ b/src/app/api/auth/callback/google/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 // This route handles the Google OAuth callback
 // It simply redirects to our actual handler in the proxy API
 export async function GET(request: NextRequest) {

--- a/src/app/api/books/[id]/progress/route.ts
+++ b/src/app/api/books/[id]/progress/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { prisma } from '@/lib/db';
 
 export async function GET(

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { prisma } from '@/lib/db';
 
 export async function GET(

--- a/src/app/api/books/[id]/summary/route.ts
+++ b/src/app/api/books/[id]/summary/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { prisma } from '@/lib/db';
 
 export async function GET(

--- a/src/app/api/books/import/route.ts
+++ b/src/app/api/books/import/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import fs from 'fs/promises';
 import path from 'path';
 import { prisma } from '@/lib/db';

--- a/src/app/api/books/process/route.ts
+++ b/src/app/api/books/process/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { getServerSession } from 'next-auth';
 
 // API endpoint to process a book after it's been uploaded to S3

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { prisma } from '@/lib/db';
 
 export async function GET() {

--- a/src/app/api/books/upload/route.ts
+++ b/src/app/api/books/upload/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { getServerSession } from 'next-auth';
 import { prisma } from '@/lib/db';
 import { uploadFile } from '@/lib/cloudinary';

--- a/src/app/api/proxy/auth/google/callback/route.ts
+++ b/src/app/api/proxy/auth/google/callback/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 // Google OAuth configuration
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;

--- a/src/app/api/proxy/auth/google/route.ts
+++ b/src/app/api/proxy/auth/google/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 // Google OAuth configuration
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;

--- a/src/app/api/proxy/books/upload-url/route.ts
+++ b/src/app/api/proxy/books/upload-url/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { getServerSession } from 'next-auth';
 
 // Proxy endpoint to get a presigned URL for uploading books

--- a/src/app/api/proxy/epub/route.ts
+++ b/src/app/api/proxy/epub/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 /**
  * Proxy route for fetching EPUB files through the server to avoid CORS issues
  */

--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const url = searchParams.get('url');

--- a/src/app/api/proxy/user/login/route.ts
+++ b/src/app/api/proxy/user/login/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();

--- a/src/app/api/proxy/user/me/route.ts
+++ b/src/app/api/proxy/user/me/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: NextRequest) {
   try {
     // Get the Authorization header from the request

--- a/src/app/api/proxy/user/register/route.ts
+++ b/src/app/api/proxy/user/register/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { Suspense } from 'react';
+
+export const dynamic = 'force-dynamic';
+
 import { useState, useEffect } from 'react';
 import LoginForm from '@/components/Auth/LoginForm';
 import RegisterForm from '@/components/Auth/RegisterForm';
 import { useSearchParams } from 'next/navigation';
 
-export default function AuthPage() {
+function AuthContent() {
   const searchParams = useSearchParams();
   const initialMode = searchParams.get('mode') === 'register' ? 'register' : 'login';
   const [authMode, setAuthMode] = useState<'login' | 'register'>(initialMode);
@@ -80,5 +84,13 @@ export default function AuthPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function AuthPage() {
+  return (
+    <Suspense fallback={null}>
+      <AuthContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap `useSearchParams` usage in `<Suspense>` and force dynamic rendering on `/auth` page
- mark all API route handlers as `force-dynamic` so Vercel doesn't try to pre-render them

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a6684dd9c8328b1cefd8a67884688