### PR TITLE
Fix Google auth profile init

### DIFF
--- a/src/app/auth-success/page.tsx
+++ b/src/app/auth-success/page.tsx
@@ -27,9 +27,9 @@ export default function AuthSuccessPage() {
             
             // Update auth context
             setToken(token);
-            
-            // Fetch user profile
-            await getProfile();
+
+            // Fetch user profile using the newly set token
+            await getProfile(token);
             
             // Redirect to the specified path
             router.push(redirectPath);

--- a/src/lib/context/AuthContext.tsx
+++ b/src/lib/context/AuthContext.tsx
@@ -11,7 +11,7 @@ type AuthContextType = {
   login: (email: string, password: string) => Promise<boolean>;
   register: (name: string, email: string, password: string) => Promise<boolean>;
   logout: () => void;
-  getProfile: () => Promise<void>;
+  getProfile: (overrideToken?: string) => Promise<void>;
   setToken: (token: string) => void;
 };
 
@@ -86,7 +86,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } else {
         // Otherwise, fetch the user profile
         console.log('AuthContext: No user data in login response, fetching profile...');
-        await getProfile();
+        await getProfile(data.token);
       }
 
       return true;
@@ -115,15 +115,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  const getProfile = async (): Promise<void> => {
-    if (!token) {
+  const getProfile = async (overrideToken?: string): Promise<void> => {
+    const authToken = overrideToken || token;
+    if (!authToken) {
       setIsLoading(false);
       return;
     }
 
     setIsLoading(true);
     try {
-      const userData = await apiGetProfile(token);
+      const userData = await apiGetProfile(authToken);
       if (!userData || !userData.id) {
         throw new Error('Invalid user data received');
       }


### PR DESCRIPTION
## Summary
- ensure Google sign-in calls `getProfile` with the new token
- allow overriding token when fetching profile

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'cloudinary' or its corresponding type declarations)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7af5d8c88328a7116f737bc767e8