### PR TITLE
Fix Google auth profile init

### DIFF
--- a/src/app/api/proxy/auth/google/callback/route.ts
+++ b/src/app/api/proxy/auth/google/callback/route.ts
@@ -127,7 +127,7 @@ export async function GET(request: NextRequest) {
         password: generatedPassword
       }),
     });
-    
+
     const authData = await loginResponse.json();
     
     if (!loginResponse.ok) {
@@ -136,12 +136,33 @@ export async function GET(request: NextRequest) {
       return NextResponse.redirect(new URL(`/auth?error=google_auth_failed&message=${encodeURIComponent(authData.message || 'Authentication failed')}`, request.url));
     }
     
+    // Fetch the user profile with the returned token so we can pass
+    // the essential user info directly to the client. This avoids a
+    // second request immediately after redirecting.
+    const profileResponse = await fetch('https://hgtv5vd4n3.execute-api.us-east-1.amazonaws.com/prod/user/me', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.token}`,
+      },
+    });
+
+    const profileData = await profileResponse.json();
+
+    if (!profileResponse.ok) {
+      console.error('Failed to fetch profile after login:', profileData);
+      return NextResponse.redirect(new URL('/auth?error=profile_fetch_failed', request.url));
+    }
+
     // Store token in localStorage on client side via a redirect with hash fragment
-    // This matches how the regular login works
-    
-    // Create URL with token in hash (not sent to server)
+    // Include basic user info so the client can initialise auth state without another fetch
     const successUrl = new URL('/auth-success', request.url);
-    successUrl.hash = `token=${authData.token}&redirect=/profile`;
+    successUrl.hash =
+      `token=${authData.token}` +
+      `&id=${encodeURIComponent(profileData.id)}` +
+      `&name=${encodeURIComponent(profileData.name)}` +
+      `&email=${encodeURIComponent(profileData.email)}` +
+      `&redirect=/profile`;
     
     console.log('Authentication successful, redirecting to:', successUrl.pathname);
     const response = NextResponse.redirect(successUrl);

--- a/src/app/auth-success/page.tsx
+++ b/src/app/auth-success/page.tsx
@@ -7,7 +7,7 @@ import LoadingBook from '@/components/LoadingBook';
 
 export default function AuthSuccessPage() {
   const router = useRouter();
-  const { setToken, getProfile } = useAuth();
+  const { setToken, setUser, getProfile } = useAuth();
 
   useEffect(() => {
     const handleAuthSuccess = async () => {
@@ -17,6 +17,9 @@ export default function AuthSuccessPage() {
           const hash = window.location.hash.substring(1); // Remove the # character
           const params = new URLSearchParams(hash);
           const token = params.get('token');
+          const userId = params.get('id');
+          const name = params.get('name');
+          const email = params.get('email');
           const redirectPath = params.get('redirect') || '/profile';
 
           if (token) {
@@ -27,9 +30,16 @@ export default function AuthSuccessPage() {
             
             // Update auth context
             setToken(token);
-            
-            // Fetch user profile
-            await getProfile();
+
+            // If we received user info in the hash, use it to initialise state
+            if (userId && name && email) {
+              const userData = { id: userId, name, email, role: 'user' };
+              setUser(userData);
+              localStorage.setItem('auth_user', JSON.stringify(userData));
+            } else {
+              // Fetch user profile using the newly set token
+              await getProfile(token);
+            }
             
             // Redirect to the specified path
             router.push(redirectPath);

--- a/src/lib/context/AuthContext.tsx
+++ b/src/lib/context/AuthContext.tsx
@@ -11,8 +11,9 @@ type AuthContextType = {
   login: (email: string, password: string) => Promise<boolean>;
   register: (name: string, email: string, password: string) => Promise<boolean>;
   logout: () => void;
-  getProfile: () => Promise<void>;
+  getProfile: (overrideToken?: string) => Promise<void>;
   setToken: (token: string) => void;
+  setUser: (user: User | null) => void;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -27,6 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const initializeAuth = async () => {
       const storedToken = localStorage.getItem('auth_token');
+      const storedUser = localStorage.getItem('auth_user');
       if (!storedToken) {
         setIsLoading(false);
         return;
@@ -35,20 +37,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       try {
         // Set a timeout for the profile fetch
         const profilePromise = apiGetProfile(storedToken);
-        const timeoutPromise = new Promise((_, reject) => 
+        const timeoutPromise = new Promise((_, reject) =>
           setTimeout(() => reject(new Error('Profile fetch timed out')), 3000)
         );
-        
+
         // Race the profile fetch against a timeout
         const userData = await Promise.race([profilePromise, timeoutPromise]);
-        
+
         setToken(storedToken);
         setUser(userData);
         setIsAuthenticated(true);
+        localStorage.setItem('auth_user', JSON.stringify(userData));
       } catch (error) {
         console.error('Auth initialization failed:', error);
-        // Clear invalid token
-        localStorage.removeItem('auth_token');
+        // If we have cached user data, use it instead of logging out
+        if (storedUser) {
+          try {
+            const parsed = JSON.parse(storedUser);
+            setToken(storedToken);
+            setUser(parsed);
+            setIsAuthenticated(true);
+          } catch (e) {
+            localStorage.removeItem('auth_token');
+            localStorage.removeItem('auth_user');
+          }
+        } else {
+          // Clear invalid token when no fallback user
+          localStorage.removeItem('auth_token');
+        }
       } finally {
         setIsLoading(false);
       }
@@ -83,10 +99,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (data.user) {
         console.log('AuthContext: Setting user data from login response:', data.user);
         setUser(data.user);
+        localStorage.setItem('auth_user', JSON.stringify(data.user));
       } else {
         // Otherwise, fetch the user profile
         console.log('AuthContext: No user data in login response, fetching profile...');
-        await getProfile();
+        await getProfile(data.token);
       }
 
       return true;
@@ -115,20 +132,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  const getProfile = async (): Promise<void> => {
-    if (!token) {
+  const getProfile = async (overrideToken?: string): Promise<void> => {
+    const authToken = overrideToken || token;
+    if (!authToken) {
       setIsLoading(false);
       return;
     }
 
     setIsLoading(true);
     try {
-      const userData = await apiGetProfile(token);
+      const userData = await apiGetProfile(authToken);
       if (!userData || !userData.id) {
         throw new Error('Invalid user data received');
       }
       setUser(userData);
       setIsAuthenticated(true);
+      localStorage.setItem('auth_user', JSON.stringify(userData));
     } catch (error) {
       console.error('Profile fetch error:', error);
       // Clear auth state on error
@@ -141,6 +160,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = () => {
     // Clear token from localStorage
     localStorage.removeItem('auth_token');
+    localStorage.removeItem('auth_user');
     
     // Reset auth state
     setToken(null);
@@ -160,6 +180,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         logout,
         getProfile,
         setToken,
+        setUser,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- ensure Google login redirects include user data
- cache user info in localStorage
- load cached user info during auth initialization

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'cloudinary' or its corresponding type declarations)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7af5d8c88328a7116f737bc767e8